### PR TITLE
フォロワー一覧からフォロー、リフォロー（＋α マージの際のバグ修正）

### DIFF
--- a/app/assets/stylesheets/follow.css
+++ b/app/assets/stylesheets/follow.css
@@ -1,5 +1,5 @@
 .followers-wrapper {
-  width: 50%;
+  width: 40%;
   height: 100vh;
   margin: 0 auto;
   border-left: 2px #EEE solid;
@@ -8,7 +8,7 @@
 
 .followers-container {
   position: fixed;
-  width: 50%;
+  width: 40%;
 }
 
 .followers-top {
@@ -139,6 +139,9 @@
   font-style: normal;
   font-weight: 600;
   line-height: normal;
+  display: inline-block;
+  background: #0E1838;
+  border: none;
 }
 
 .unfollow-btn-container {
@@ -156,10 +159,12 @@
 .unfollow-btn {
   color: #0E1838;
   font-family: "Hiragino Sans";
-  font-size: 14px;
+  font-size: 13px;
   font-style: normal;
   font-weight: 600;
   line-height: normal;
+  background: #FFF;
+  border: none;
 }
 
 .text-center {

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -1,6 +1,6 @@
 .main-container {
   width: 100%;
-  height: 100%;
+  /* height: 100%; */
   /* padding-left: 18px; */
   border: solid #EEE;
 }

--- a/app/assets/stylesheets/modal.css
+++ b/app/assets/stylesheets/modal.css
@@ -87,7 +87,7 @@
   padding: 16px 16px;
   border-radius: 4px;
   width: 40%;
-  height: 31%;
+  height: auto;
   text-align: center;
 }
 
@@ -127,28 +127,6 @@
   font-style: normal;
   font-weight: 600;
   line-height: normal;
-}
-
-
-
-#tweetModal {
-  background: rgba(0, 0, 0, 0.50);
-}
-
-#tweetContent {
-  background-color: #fefefe;
-  margin: 94px auto;
-  padding: 16px 16px;
-  border-radius: 4px;
-  width: 40%;
-  height: 31%;
-  text-align: center;
-}
-
-#modal-tweet-form {
-  margin-left: 39px;
-  margin-right: 0px;
-  width: 100%;
 }
 
 cancelUnfollow .close {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -18,10 +18,10 @@ before_action :authenticate_user!
     def create
       @post = current_user.posts.build(post_params)
   
-      # フォームから送信された緯度・経度が空でない場合にはそれを使い、空の場合はIPアドレスから取得
-      if @post.latitude.blank? || @post.longitude.blank?
-        @post.geocode
-      end
+      # # フォームから送信された緯度・経度が空でない場合にはそれを使い、空の場合はIPアドレスから取得
+      # if @post.latitude.blank? || @post.longitude.blank?
+      #   @post.geocode
+      # end
   
       if @post.save
         @post.update(map_image_url: generate_map_image_url(@post.latitude, @post.longitude))

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,12 +21,14 @@ class UsersController < ApplicationController
 
   def follow
     current_user.follow(@user_to_follow)
-    redirect_to user_path(@user_to_follow)
+    # redirect_to user_path(@user_to_follow) user_pathにリダイレクトすると、フォロワー一覧画面からフォローした際に画面が遷移してしまうため元の画面に戻すように変更
+    redirect_back(fallback_location: user_path(@user_to_follow))
   end
 
   def unfollow
     current_user.unfollow(@user_to_follow)
-    redirect_to user_path(@user_to_follow)
+    # redirect_to user_path(@user_to_follow)　上に同じ
+    redirect_back(fallback_location: user_path(@user_to_follow))
   end
 
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,11 +7,17 @@ class Post < ApplicationRecord
     :latitude => :latitude, :longitude => :longitude
 
   after_validation :geocode
+  # before_validation :geocode
+
 
   attr_accessor :map_image_url
 
   def ip_address
-    request.remote_ip if defined?(request)
+    if defined?(request)
+      request.remote_ip
+    else
+      ENV['REMOTE_ADDR']
+    end
   end
 
   def map_image_url

--- a/app/views/followers/index.html.erb
+++ b/app/views/followers/index.html.erb
@@ -32,15 +32,15 @@
           <p class="follower-name"><%= follower.name %></p>
           <p class="follower-user_name"><%= follower.user_name %></p>
         </div>
-        <% if @following.include?(follower) %>
-          <div class="unfollow-btn-container">
-            <%= link_to "フォロー中", "#", class: "unfollow-btn text-center", disabled: true %>
-          </div>
-        <% else %>
-          <div class="follow-btn-container">
-            <%= link_to "フォロー", "#", class: "follow-btn text-center" %>
-          </div>
-        <% end %>
+          <% if @following.include?(follower) %>
+            <div class="unfollow-btn-container">
+              <%= button_to "フォロー中", unfollow_user_path(follower), method: :delete, class: "unfollow-btn text-center" %>
+            </div>
+          <% else %>
+            <div class="follow-btn-container">
+              <%= button_to "フォロー", follow_user_path(follower), method: :post, class: "follow-btn text-center" %>
+            </div>
+          <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/followers/index.html.erb
+++ b/app/views/followers/index.html.erb
@@ -15,9 +15,9 @@
       <div class="followers-tab">
         <p class="followers-tab-text">フォロワー</p>
       </div>
-      <div class="followings_tab">
-        <p class="followings-tab-text">フォロー中</p>
-      </div>
+    <div class="followings_tab">
+      <%= link_to "フォロー中", follows_user_path(@user), class: "followings-tab-text" %>
+    </div>
     </div>
   </div>
   <div class="followers-info">


### PR DESCRIPTION
## 実装内容：

- フォロワー一覧からフォロー、リフォロー
- 画面上部切り替えタブ実装
- バグ修正

- [ ] ユーザー新規登録ができない
→application.jsが削除されていた（復旧済み）

- [ ] devise.views.ja.ymlが削除されている
→復旧済み

- [ ] ツイートモーダルの表示崩れ（cssがなぜか効かない）
→修正済み（マージした際に同じ箇所のcssコードが重複して付け加えられていた）

## Figmaリンク(URL)
https://www.figma.com/file/l8Zzw1wPJBitm0bQMNXTdB/%E3%82%A4%E3%83%9E%E3%82%B3%E3%82%B3SNS?node-id=66%3A1054&mode=dev

## チケット(URL)
https://docs.google.com/spreadsheets/d/16OjkTL5iEZY6XfnUBcWwuEZZNT6DrWhb7zhvL7HTgpI/edit?pli=1#gid=1023786153

## エビデンス

Uploading 画面収録 2024-02-01 23.44.17.mov…


