### PR TITLE
fix#60 

### DIFF
--- a/app/views/posts/_main.html.erb
+++ b/app/views/posts/_main.html.erb
@@ -50,7 +50,7 @@
 
     <div class="tweet-reaction">
       <%= image_tag('comment.svg', alt: 'Icon', class: 'comment-img') %>
-      <p class="comment-count">6</p>
+      <p class="comment-count"><%= post.comments.count %></p>
       <%= image_tag('favorite.svg', alt: 'Icon', class: 'favorite-img') %>
       <p class="like-count">10</p>
       <%= image_tag('delete.svg', alt: 'Icon', class: 'delete-img') %>


### PR DESCRIPTION
## 概要
TOP投稿一覧のコメント数表示を仮表示から実数値に修正

現状：仮置きした数字を表示
期待値：投稿ごとのコメント数に応じて表示
修正：期待値通り

## エビデンス
No.3
https://docs.google.com/spreadsheets/d/16OjkTL5iEZY6XfnUBcWwuEZZNT6DrWhb7zhvL7HTgpI/edit?pli=1#gid=1344938857