### PR TITLE
Fix#78 ログイン/新規登録画面フォームラベル日本語読み込み

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module Myapp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
-
+    config.i18n.default_locale = :ja
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -37,7 +37,7 @@ Devise.setup do |config|
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
   require 'devise/orm/active_record'
-
+  config.scoped_views = true
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is
   # just :email. You can configure it to use [:username, :subdomain], so for


### PR DESCRIPTION
## 概要

現状：devise.views.ja.ymlの内容が読み込まれておらず、フォームラベルが日本語化されていない
期待値：フォームラベルが日本語化されていること
修正：期待値に同じ

## デザイン

https://www.figma.com/file/l8Zzw1wPJBitm0bQMNXTdB/%E3%82%A4%E3%83%9E%E3%82%B3%E3%82%B3SNS?node-id=0%3A1&mode=dev

## エビデンス

No.9
https://docs.google.com/spreadsheets/d/16OjkTL5iEZY6XfnUBcWwuEZZNT6DrWhb7zhvL7HTgpI/edit?pli=1#gid=1344938857
