### PR TITLE
Fix#80 ツイートモーダルのuser_name先頭に＠を表示、その他軽微なフロントバグ修正

### DIFF
--- a/app/assets/stylesheets/index.css
+++ b/app/assets/stylesheets/index.css
@@ -3,7 +3,7 @@
     height: 100%;
     width: 100%;
     position: relative;
-    margin-top: 417px;
+    margin-top: 450px;
 }
 
 /* 単体の投稿表示エリア */

--- a/app/views/followers/index.html.erb
+++ b/app/views/followers/index.html.erb
@@ -26,7 +26,7 @@
         <% if follower.user_icon.present? %>
           <%= image_tag follower.user_icon, alt: "User Icon", class: "follower-icon" %>
         <% else %>
-          <%= image_tag('prum.png', size: '48x48', class: 'user-icon') %>
+          <%= image_tag('prum.png', size: '48x48', class: 'follower-icon') %>
         <% end %>
         <div class="follower-names">
           <p class="follower-name"><%= follower.name %></p>

--- a/app/views/posts/_madal.html.erb
+++ b/app/views/posts/_madal.html.erb
@@ -40,7 +40,7 @@
   };
 </script>
 
-
+<%# ツイートモーダル %>
 <div id="tweetModal" class="modal">
   <div class="modal-content" id="tweetContent">
     <span class="close"><%= image_tag('close.svg', alt: "Close", class: "closeButton", onclick: "closeModal()") %></span>
@@ -51,7 +51,7 @@
         <%= image_tag 'prum.png', class: "author-icon" %>
       <% end %>
       <p class="author-name"><%= current_user.name %></p>
-       <p class="author-user_name"><%= current_user.user_name %></p>
+       <p class="author-user_name"><%= "@" +  current_user.user_name %></p>
     </div>
     <div class="tweet-area">
       <%= form_with(model: @post_new, url: posts_path, class: "tweet-form", id: "modal-tweet-form", local: true) do |form| %>


### PR DESCRIPTION
## 概要

現状：ツイートモーダルにuser_name先頭に＠が表示されていない
期待値：他画面に揃えて＠を表示
修正：期待値に同じ

## デザイン
https://www.figma.com/file/l8Zzw1wPJBitm0bQMNXTdB/%E3%82%A4%E3%83%9E%E3%82%B3%E3%82%B3SNS?node-id=0%3A1&mode=dev

## エビデンス
No.10
https://docs.google.com/spreadsheets/d/16OjkTL5iEZY6XfnUBcWwuEZZNT6DrWhb7zhvL7HTgpI/edit?pli=1#gid=1344938857