### PR TITLE
Fix#82 フォロワー一覧画面のフォローボタン表示の修正

### DIFF
--- a/app/controllers/followers_controller.rb
+++ b/app/controllers/followers_controller.rb
@@ -4,7 +4,7 @@ class FollowersController < ApplicationController
   def index
     @user = User.find(params[:id])
     @followers = @user.followers
-    @following = @user.following
+    @following = current_user.following
     @post_new =Post.new
   end
 

--- a/app/views/followers/index.html.erb
+++ b/app/views/followers/index.html.erb
@@ -32,15 +32,18 @@
           <p class="follower-name"><%= follower.name %></p>
           <p class="follower-user_name"><%= "@" + follower.user_name %></p>
         </div>
-        <% if @following.include?(follower) %>
-          <div class="unfollow-btn-container">
-            <%= button_to "フォロー中", '#', method: :get, class: "unfollow-btn", id: "unfollow_modal_#{follower.id}" %>
-          </div>
+        <% unless current_user == follower %>
+          <% if @following.include?(follower) %>
+            <di class="unfollow-btn-container">
+              <%= button_to "フォロー中", '#', method: :get, class: "unfollow-btn", id: "unfollow_modal_#{follower.id}" %>
+          </di  v>
         <% else %>
           <div class="follow-btn-container">
             <%= button_to "フォロー", follow_user_path(follower), method: :post, class: "follow-btn text-center" %>
           </div>
         <% end %>
+      <% end %>
+
       </div>
     <% end %>
   </div>

--- a/app/views/followers/index.html.erb
+++ b/app/views/followers/index.html.erb
@@ -34,16 +34,15 @@
         </div>
         <% unless current_user == follower %>
           <% if @following.include?(follower) %>
-            <di class="unfollow-btn-container">
+            <div class="unfollow-btn-container">
               <%= button_to "フォロー中", '#', method: :get, class: "unfollow-btn", id: "unfollow_modal_#{follower.id}" %>
-          </di  v>
-        <% else %>
-          <div class="follow-btn-container">
-            <%= button_to "フォロー", follow_user_path(follower), method: :post, class: "follow-btn text-center" %>
-          </div>
+            </div>
+          <% else %>
+            <div class="follow-btn-container">
+              <%= button_to "フォロー", follow_user_path(follower), method: :post, class: "follow-btn text-center" %>
+            </div>
+          <% end %>
         <% end %>
-      <% end %>
-
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## 概要

 ### フォロワー一覧画面のフォロー表示をログインユーザー基準に修正

> 現状：表示ユーザーのフォロー情報が反映されている
> 期待値：フォローボタンはログインユーザーのフォロー状態に準じて表示する
> 修正：期待値に同じ

### 他ユーザーのフォロワー一覧で自分が表示されていた場合、フォローボタンを非表示

> 現状：他ユーザーのフォロワー一覧画面でログインユーザーにもフォローボタンが表示されている
> 期待値：ログインユーザーの表示箇所にはフォローボタンを非表示にする
> 修正：期待値に同じ

## デザイン
https://www.figma.com/file/l8Zzw1wPJBitm0bQMNXTdB/%E3%82%A4%E3%83%9E%E3%82%B3%E3%82%B3SNS?node-id=0%3A1&mode=dev

## エビデンス
No.11,12
https://docs.google.com/spreadsheets/d/16OjkTL5iEZY6XfnUBcWwuEZZNT6DrWhb7zhvL7HTgpI/edit?pli=1#gid=1344938857
