### PR TITLE
色変更

### DIFF
--- a/app/assets/stylesheets/top.css
+++ b/app/assets/stylesheets/top.css
@@ -153,6 +153,7 @@ li {
 .unfollow-button {
   border-radius: 30px;
   background-color: #ffffff;
+  color: black;
   width: 120%;
 }
 


### PR DESCRIPTION
# 概要
バグ修正

# フォローボタンを色変更
現状：フォロー中ボタンが黒、フォローボタンが白
期待値：フォロー中ボタンが白、フォローボタンが黒
修正：フォロー中ボタンが白、フォローボタンが黒


エビデンス(Apidog、Postman、SQL実行計画の結果など必要に応じて添付)
<img width="1440" alt="スクリーンショット 2024-02-15 20 24 51" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/112809549/5a1f79de-1712-4b76-aff5-8cd319f5754e">

<img width="1440" alt="スクリーンショット 2024-02-15 20 24 55" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/112809549/515c847c-8760-4593-9c64-8f9aa9333d0d">



