### PR TITLE
Fix#99

### DIFF
--- a/app/assets/stylesheets/index.css
+++ b/app/assets/stylesheets/index.css
@@ -3,7 +3,7 @@
     height: 100%;
     width: 100%;
     position: relative;
-    margin-top: 450px;
+    margin-top: 400px;
 }
 
 /* 単体の投稿表示エリア */

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -45,8 +45,8 @@
       </div>
     </div>
     <div class="transition">
-      <%= link_to "ツイート", user_path(@user),style: "color: black;", class: "tweet_link #{current_page?(root_path) ? 'active' : ''}", aria_current: "page" %>
-      <%= link_to "ツイートと返信", comments_path(user_id: @user),style: "color: #777777;", class: "reply_link #{current_page?(comments_path) ? 'active' : ''}", aria_current: "page" %>
+      <%= link_to "ツイート", user_path(@user),style: "color: #777777;", class: "tweet_link #{current_page?(root_path) ? 'active' : ''}", aria_current: "page" %>
+      <%= link_to "ツイートと返信", comments_path(user_id: @user),style: "color: black;", class: "reply_link #{current_page?(comments_path) ? 'active' : ''}", aria_current: "page" %>
     </div>
   </div>
   <div class="post_area">


### PR DESCRIPTION
# 概要
バグ解消

# 実装内容
現状：リンクの文字が灰色
期待値：現在表示しているリンクの色が黒、していないリンクを灰色
修正：現在表示しているリンクの色が黒、していないリンクを灰色

# エビデンス
<img width="1440" alt="スクリーンショット 2024-02-17 21 26 01" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/112809549/08ea1520-7f7e-4e9f-8dbc-4e64a9ca159e">


<img width="1440" alt="スクリーンショット 2024-02-17 21 32 37" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/112809549/f1cc71f2-9ade-4ff4-8354-6d08376ce137">
