### PR TITLE
Fix#120

### DIFF
--- a/app/assets/stylesheets/index.css
+++ b/app/assets/stylesheets/index.css
@@ -3,7 +3,6 @@
     height: 100%;
     width: 100%;
     position: relative;
-    margin-top: 400px;
 }
 
 /* 単体の投稿表示エリア */

--- a/app/assets/stylesheets/index.css
+++ b/app/assets/stylesheets/index.css
@@ -193,5 +193,5 @@ td.submit_area {
 
 .scroll-show-post {
     height: 100%;
-    margin-top: 396px;
+    margin-top: 408px;
 }

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -90,7 +90,8 @@ input[type="submit"].top-tweet {
   padding-top: 12px;
   padding-left: 12px;
   padding-right: 63px;
-  border-bottom: solid #EEEEEE;
+  border: solid #EEE;
+  border-top: none;
 }
 
 .author-info {

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,8 +11,9 @@ class CommentsController < ApplicationController
     end
 
     def show
-      @user = User.find(current_user.id)
       @comment = Comment.find(params[:id])
+      @user = @comment.user
+      @user_current = User.find(current_user.id)
       @comments = @comment.replies.order(created_at: :desc)
     end
 

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -49,7 +49,8 @@
       <%= link_to "ツイートと返信", comments_path(user_id: @user),style: "color: black;", class: "reply_link #{current_page?(comments_path) ? 'active' : ''}", aria_current: "page" %>
     </div>
   </div>
-  <div class="post_area">
+  <%# フォローボタンがある時とない時で高さ調整%>
+  <div class="post_area" style="<% if @user.id.to_s != current_user.id.to_s %> margin-top: 425px; <% else %> margin-top: 400px; <% end %>">
       <%= render 'comments/index' %>
   </div>
 </div>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -5,18 +5,18 @@
 <div class="main_area">
   <div class="post-container">    <%#親コメント表示エリア %>
     <div class="post-img">
-      <% if @comment.user && @comment.user.user_icon.attached? %>
-        <%= image_tag @comment.user.user_icon.variant(resize: '48x48'), class: 'user-icon' %>
+      <% if @user.user_icon.attached? %>
+        <%= image_tag @user.user_icon, class: "author-icon" %>
       <% else %>
-        <%= image_tag('prum.png', size: '48x48', class: 'user-icon') %>
+        <%= image_tag 'prum.png', class: "author-icon" %>
       <% end %>
       <table class="post-table">
         <tbody>
           <tr>
             <td>
-              <span class="name"><%= @comment.user.name %></span>
-              <span class="user_name">@<%= @comment.user.user_name %></span>
-              <span class="timestamp"><%= time_ago_in_words(@comment.created_at) %></span>
+              <span class="name"><%= @user.name %></span>
+              <span class="user_name">@<%= @user.user_name %></span>
+              <span class="timestamp"><%= time_ago_in_words(@user.created_at) %></span>
             </td>
           </tr>
           <td>
@@ -46,8 +46,8 @@
     <%= form_with(model: Comment.new, local: true ) do |form| %>
       <div class="comment-form-wrapper">
         <td class="submit_area">
-          <% if @user.user_icon.attached? %>
-            <%= image_tag @user.user_icon, class: "author-icon" %>
+          <% if @user_current.user_icon.attached? %>
+            <%= image_tag @user_current.user_icon, class: "author-icon" %>
           <% else %>
             <%= image_tag 'prum.png', class: "author-icon" %>
           <% end %>
@@ -55,7 +55,7 @@
             <%= form.text_field :body, class: 'reply_body', placeholder: '返信をツイート' %>
             <%= form.hidden_field :post_id, value: @comment.post_id %>
             <%= form.hidden_field :parent_id, value: @comment.id %>
-            <%= form.hidden_field :user_id, value: @user.id %>
+            <%= form.hidden_field :user_id, value: @user_current.id %>
           </div>
           <div class="reply ">
             <%= form.submit '返信', class: 'reply_button' %>
@@ -117,3 +117,6 @@
     });
   });
 </script>
+
+<%# モーダル表示%>
+<%= render 'posts/madal' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -49,7 +49,8 @@
       <%= link_to "ツイートと返信", comments_path(user_id: @user),style: "color: #777777;", class: "reply_link #{current_page?(comments_path) ? 'active' : ''}", aria_current: "page" %>
     </div>
   </div>
-  <div class="post_area">
+  <%# フォローボタンがある時とない時で高さ調整%>
+  <div class="post_area" style="<% if @user.id.to_s != current_user.id.to_s %> margin-top: 425px; <% else %> margin-top: 400px; <% end %>">
       <%= render 'posts/index' %>
   </div>
 </div>


### PR DESCRIPTION
# 概要
バグ修正

# 内容:投稿詳細のコメント一覧表示、コメント詳細ページにサイドの線がない（見た目の問題）
現状:サイドのボーダーが表示されていない

期待値:サイドのボーダーが表示される

# エビデンス
<img width="1440" alt="スクリーンショット 2024-03-03 19 15 16" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/112809549/77b28cf0-054e-478a-9a2c-5ff39048908f">
<img width="1440" alt="スクリーンショット 2024-03-03 19 22 38" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/112809549/f79af720-8923-4279-9fea-1b493c4bf769">
<img width="1440" alt="スクリーンショット 2024-03-03 19 24 14" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/112809549/4253bc72-6bd6-4ec3-962c-430504abce37">
