### PR TITLE
Fix#131

### DIFF
--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -142,6 +142,7 @@ input[type="submit"].top-tweet {
   font-style: normal;
   font-weight: 600;
   line-height: normal;
+  overflow-wrap: break-word;
 }
 
 .map-area {


### PR DESCRIPTION
## 文字数が多い投稿の表示崩れを修正
修正前：文字が表示エリア外にはみ出している
修正後：文字がエリア内で折り返して表示される

## エビデンス
・修正前
<img width="602" alt="image" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/72453064/cb6ac93f-418f-490b-9320-15c3085f2cc9">


・修正後
<img width="574" alt="image" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/72453064/a1ae7031-de3e-4685-82a1-ba86d41c28f2">
