### PR TITLE
Fix#143

### DIFF
--- a/app/assets/stylesheets/signup.css
+++ b/app/assets/stylesheets/signup.css
@@ -71,6 +71,7 @@ input {
   font-style: normal;
   font-weight: 600;
   line-height: normal;
+  padding-left: 10px;
 }
 
 .field input::placeholder {

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,7 +17,7 @@
 
       <div class="field">
         <%= f.label :user_name %>
-        <%= f.text_field :user_name, placeholder: "@tanaka.0101" %>
+        <%= f.text_field :user_name, placeholder: "tanaka.0101" %>
       </div>
 
       <div class="field">


### PR DESCRIPTION
## 新規登録/ログイン画面見た目修正



- [ ] 新規登録画面のユーザーネーム項目のプレースホルダーから＠を削除（紛らわしいため）
- [ ] 新規登録/ログインフォーム内左部に余白を設ける

## エビデンス

###  新規登録画面のユーザーネーム項目のプレースホルダーから＠を削除（紛らわしいため）
修正前なし

修正後
<img width="698" alt="image" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/72453064/dafa9d1a-17b4-4723-9f8e-55aec42250ff">

### 新規登録/ログインフォーム内左部に余白を設ける
修正前なし

修正後
<img width="995" alt="image" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/72453064/486e1f00-f150-460d-9def-3eb5533dde4b">

