### PR TITLE
Fix#145

### DIFF
--- a/app/assets/stylesheets/follow.css
+++ b/app/assets/stylesheets/follow.css
@@ -99,6 +99,7 @@
 
 .follower-names {
   margin-left: 5px;
+  max-width: 65%;
 }
 
 .follower-name {
@@ -108,6 +109,7 @@
   font-style: normal;
   font-weight: 700;
   line-height: normal;
+  overflow-wrap: break-word;
 }
 
 .follower-user_name {
@@ -298,6 +300,7 @@
 
 .follow-date-name {
   padding-left: 25px;
+  max-width: 400px;
 }
 
 .follow-date-icon {
@@ -308,6 +311,8 @@
 .following-name {
   padding: 0;
   padding-top: 11px;
+  width: 100%;
+  overflow-wrap: break-word;
 }
 
 .following-user-name {

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -121,6 +121,8 @@ input[type="submit"].top-tweet:disabled {
   font-style: normal;
   font-weight: 700;
   line-height: normal;
+  max-width: 50%;
+  overflow: hidden;
 }
 
 .author-user_name {
@@ -131,6 +133,8 @@ input[type="submit"].top-tweet:disabled {
   font-style: normal;
   font-weight: 600;
   line-height: normal;
+  max-width: 20%;
+  overflow: hidden;
 }
 
 .posted-at {

--- a/app/assets/stylesheets/signup.css
+++ b/app/assets/stylesheets/signup.css
@@ -185,6 +185,14 @@ hr {
   height: 100%;
 }
 
+.confirm-to-session {
+  text-align: left;
+}
+
+.session-link {
+  font-weight: bold;
+}
+
 @-webkit-keyframes fade-in-out {
   0% {
     visibility: visible;

--- a/app/assets/stylesheets/top.css
+++ b/app/assets/stylesheets/top.css
@@ -147,6 +147,10 @@ li {
   width: 39.8%;
 }
 
+.name_area {
+  overflow-wrap: break-word;
+}
+
 /*  画像表示エリア  */
 .profile_area {
   width: 100%;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,9 @@ class User < ApplicationRecord
          :recoverable, :rememberable,
          authentication_keys: [:login] 
   
-  validates :email, presence: true, uniqueness: true, format: { with: /\A[^@\s]+@[^@\s]+\z/ }
-  validates :name, presence: true
-  validates :user_name, presence: true, uniqueness: true, format: { with: /\A[\w]+\z/, message: "は英数字とアンダースコアのみ使用できます" }
+  validates :email, presence: true, uniqueness: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  validates :name, presence: true, length: { in: 1..50 }
+  validates :user_name, presence: true, uniqueness: true, length: { in: 5..15 }, format: { with: /\A[\w]+\z/, message: "は英数字とアンダースコアのみ使用できます" }
   validates :password, presence: true, length: { minimum: 6 }
 
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -40,7 +40,7 @@
       <hr>
     <% end %>
 
-    <%= render "devise/shared/links" %>
+    <p class="confirm-to-session">アカウントをお持ちですか？<%= render "devise/shared/links" %></p>
   </div>
 </div>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "ログインする", new_session_path(resource_name) %><br />
+  <%= link_to "ログインする", new_session_path(resource_name), class: "session-link" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -46,10 +46,14 @@ ja:
           attributes:
             name:
               blank: "を入力してください"
+              too_short: "は%{count}文字以上で入力してください"
+              too_long: "は%{count}文字以内で入力してください"
             user_name:
               blank: "を入力してください"
               taken: "はすでに使用されています"
               invalid: "は英数字とアンダースコアのみ使用できます"
+              too_short: "は%{count}文字以上で入力してください"
+              too_long: "は%{count}文字以内で入力してください"
             email:
               blank: "を入力してください"
               invalid: "が無効です"


### PR DESCRIPTION
## 新規登録 バリデーション追加

### 変更点 （仕様はXにならって実装）

- フルネーム：1〜50文字で設定可能
- ユーザーネーム：5〜15文字、英数字＋アンダースコアのみ、一意
- XXXX＠YYYY.ZZZZの形式で正規表現を追加（以前はa@aでも登録可能だった）

### ビューの修正

- TOPにおいてフルネーム、ユーザーネームが長い場合は一定の範囲外で非表示（Xの仕様と同じ）
- プロフィール画面ではフルネームは改行して表示
-  新規登録下部のログインリンクの表示を修正（アカウントはお持ちですか？の文言追加）


## エビデンス

### バリデーション（エラーメッセージで確認）
<img width="737" alt="image" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/72453064/8969f7ab-9746-43ea-a15f-a9008df535f3">

### ビュー
・TOP画面
<img width="573" alt="image" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/72453064/1e275ff6-0522-45c8-88ae-7544d05b541b">
<img width="600" alt="image" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/72453064/8cfb3f5e-fe97-4191-8e93-72b41d5189b2">

・プロフィール画面
<img width="573" alt="image" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/72453064/dbd50435-bdb1-45d8-9963-70dce2c29876">

・フォロー中、フォロワー一覧画面
フォロー中一覧
<img width="570" alt="image" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/72453064/e87f26ec-c0d0-450d-8690-71311a699035">

フォロワー一覧
<img width="575" alt="image" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/72453064/a669a2be-c6e4-4253-a74d-986fb73ab98e">

・新規登録画面
<img width="1063" alt="image" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/72453064/51de94cd-f5b8-4967-9809-266aac9a8842">

