### PR TITLE
Fix#149

### DIFF
--- a/app/assets/stylesheets/follow.css
+++ b/app/assets/stylesheets/follow.css
@@ -179,9 +179,10 @@
   border: solid 2px #EEEEEE
 }
 
-.back-to-user-button i {
-  margin-left: 18px;
-  /* 右側に5pxの余白を追加 */
+.back-to-user-button {
+  margin-top: 9px;
+  margin-left: 16px;
+  color: #777;
 }
 
 .follow_name {

--- a/app/assets/stylesheets/follow.css
+++ b/app/assets/stylesheets/follow.css
@@ -99,6 +99,7 @@
 
 .follower-names {
   margin-left: 5px;
+  max-width: 65%;
 }
 
 .follower-name {
@@ -108,6 +109,7 @@
   font-style: normal;
   font-weight: 700;
   line-height: normal;
+  overflow-wrap: break-word;
 }
 
 .follower-user_name {
@@ -299,6 +301,7 @@
 
 .follow-date-name {
   padding-left: 25px;
+  max-width: 400px;
 }
 
 .follow-date-icon {
@@ -309,6 +312,8 @@
 .following-name {
   padding: 0;
   padding-top: 11px;
+  width: 100%;
+  overflow-wrap: break-word;
 }
 
 .following-user-name {

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -71,6 +71,12 @@ input[type="submit"].top-tweet {
   margin-left: auto;
 }
 
+/* ボタン非活性時の色 */
+input[type="submit"].top-tweet:disabled {
+  background-color: #707070;
+  /* グレーなどの適切な色に変更 */
+}
+
 .relord-tweets {
   margin-top: 206px;
   color: #707070;

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -77,6 +77,10 @@ input[type="submit"].top-tweet:disabled {
   /* グレーなどの適切な色に変更 */
 }
 
+input[type="submit"].top-tweet:hover {
+  cursor: pointer;
+}
+
 .relord-tweets {
   margin-top: 206px;
   color: #707070;

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -125,6 +125,8 @@ input[type="submit"].top-tweet:hover {
   font-style: normal;
   font-weight: 700;
   line-height: normal;
+  max-width: 50%;
+  overflow: hidden;
 }
 
 .author-user_name {
@@ -135,6 +137,8 @@ input[type="submit"].top-tweet:hover {
   font-style: normal;
   font-weight: 600;
   line-height: normal;
+  max-width: 20%;
+  overflow: hidden;
 }
 
 .posted-at {

--- a/app/assets/stylesheets/signup.css
+++ b/app/assets/stylesheets/signup.css
@@ -71,6 +71,7 @@ input {
   font-style: normal;
   font-weight: 600;
   line-height: normal;
+  padding-left: 10px;
 }
 
 .field input::placeholder {
@@ -183,6 +184,14 @@ hr {
   background-color: rgba(197, 242, 200, 0.988);
   color: rgba(1, 73, 41, 0.944);
   height: 100%;
+}
+
+.confirm-to-session {
+  text-align: left;
+}
+
+.session-link {
+  font-weight: bold;
 }
 
 @-webkit-keyframes fade-in-out {

--- a/app/assets/stylesheets/top.css
+++ b/app/assets/stylesheets/top.css
@@ -96,6 +96,11 @@ li {
 
 }
 
+.tweet-button:disabled {
+  background-color: #707070;
+  border: 2px solid #707070;
+}
+
 /* ホームボタン */
 .home_button {
   text-decoration: none;

--- a/app/assets/stylesheets/top.css
+++ b/app/assets/stylesheets/top.css
@@ -151,6 +151,10 @@ li {
   width: 39.8%;
 }
 
+.name_area {
+  overflow-wrap: break-word;
+}
+
 /*  画像表示エリア  */
 .profile_area {
   width: 100%;

--- a/app/assets/stylesheets/top.css
+++ b/app/assets/stylesheets/top.css
@@ -96,6 +96,10 @@ li {
 
 }
 
+.tweet-button:hover {
+  cursor: pointer;
+}
+
 .tweet-button:disabled {
   background-color: #707070;
   border: 2px solid #707070;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -29,7 +29,8 @@ before_action :set_cache_headers
       @post = Post.find(params[:id])
       @post_new =Post.new
       @user = User.find(current_user.id)
-      @comments = @post.comments.order(created_at: :desc)
+      # 孫コメントを表示させない
+      @comments = @post.comments.where(parent_id: nil).order(created_at: :desc)
       @users = current_user.following
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,9 @@ class User < ApplicationRecord
          :recoverable, :rememberable,
          authentication_keys: [:login] 
   
-  validates :email, presence: true, uniqueness: true, format: { with: /\A[^@\s]+@[^@\s]+\z/ }
-  validates :name, presence: true
-  validates :user_name, presence: true, uniqueness: true, format: { with: /\A[\w]+\z/, message: "は英数字とアンダースコアのみ使用できます" }
+  validates :email, presence: true, uniqueness: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  validates :name, presence: true, length: { in: 1..50 }
+  validates :user_name, presence: true, uniqueness: true, length: { in: 5..15 }, format: { with: /\A[\w]+\z/, message: "は英数字とアンダースコアのみ使用できます" }
   validates :password, presence: true, length: { minimum: 6 }
 
 

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -98,16 +98,16 @@
 </div>
 <%# data-post-idから投稿詳細のリンクを生成、またuserIdを取得しアイコンクリック時はユーザー詳細画面に遷移するよう制御 %>
 <script>
-  document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener("DOMContentLoaded", function() {
   document.querySelectorAll(".tweet-wrapper-comment").forEach(function(wrapper) {
-  // コメント本文をクリックした場合の処理
-  wrapper.addEventListener("click", function(event) {
-  // クリックした要素がいいねボタンでない場合は、コメントの詳細ページにリダイレクト
-  if (!event.target.classList.contains("like-btn")) {
-  var commentId = this.dataset.commentId;
-  window.location.href = "/comments/" + commentId;
-  }
-  });
+    // コメント本文をクリックした場合の処理
+    wrapper.addEventListener("click", function(event) {
+      // クリックした要素がいいねボタンでない場合は、コメントの詳細ページにリダイレクト
+      if (!event.target.classList.contains("like-btn")) {
+        var commentId = this.dataset.commentId;
+        window.location.href = "/comments/" + commentId;
+      }
+    });
 
   wrapper.querySelector(".author-icon").addEventListener("click", function(e) {
   e.stopPropagation();

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,7 +17,7 @@
 
       <div class="field">
         <%= f.label :user_name %>
-        <%= f.text_field :user_name, placeholder: "@tanaka.0101" %>
+        <%= f.text_field :user_name, placeholder: "tanaka.0101" %>
       </div>
 
       <div class="field">
@@ -40,7 +40,7 @@
       <hr>
     <% end %>
 
-    <%= render "devise/shared/links" %>
+    <p class="confirm-to-session">アカウントをお持ちですか？<%= render "devise/shared/links" %></p>
   </div>
 </div>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "ログインする", new_session_path(resource_name) %><br />
+  <%= link_to "ログインする", new_session_path(resource_name), class: "session-link" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/app/views/followers/index.html.erb
+++ b/app/views/followers/index.html.erb
@@ -5,7 +5,7 @@
 <div class="followers-wrapper">
   <div class="followers-container">
     <div class="followers-top">
-      <%= link_to "←", :back, class: "return-button" %>
+      <%= link_to "←", user_path(@user), class: "return-button" %>
       <div class="user-info">
         <p class="followers-user-name"><%= @user.name %></p>
         <p class="followers-user-user_name"><%= "@" + @user.user_name %></p>
@@ -24,9 +24,13 @@
     <% @followers.each do |follower| %>
       <div class="follower-info">
         <% if follower.user_icon.present? %>
+        <%= link_to user_path(follower) do %>
           <%= image_tag follower.user_icon, alt: "User Icon", class: "follower-icon" %>
+        <% end %>
         <% else %>
+        <%= link_to user_path(follower) do %>
           <%= image_tag('prum.png', size: '48x48', class: 'follower-icon') %>
+        <% end %>
         <% end %>
         <div class="follower-names">
           <p class="follower-name"><%= follower.name %></p>

--- a/app/views/followers/index.html.erb
+++ b/app/views/followers/index.html.erb
@@ -58,7 +58,7 @@
 <% @followers.each do |follower| %>
   <div id="unfollowModal_<%= follower.id %>" class="modal">
     <div class="modal-content">
-      <p class="text-confirm"><%= "#{follower.name} さんをフォロー解除しますか？" %></p>
+      <p class="text-confirm"><%= "＠#{follower.user_name} さんをフォロー解除しますか？" %></p>
       <p class="text-guide">このアカウントのツイートはホームタイムラインに表示されなくなります。ツイートが非公開になっている場合を除き、プロフィールを表示することはできます。</p>
       <%= button_to 'フォロー解除', unfollow_user_path(follower), method: :delete, class: 'follow-madal-button', id: "unfollowButton_#{follower.id}" %>
       <button class="cancelUnfollow">キャンセル</button>

--- a/app/views/follows/index.html.erb
+++ b/app/views/follows/index.html.erb
@@ -75,7 +75,7 @@
 <% @followed_users.each do |following_user| %>
   <div id="unfollowModal_<%= following_user.id %>" class="modal">
     <div class="modal-content">
-      <p class="text-confirm"><%= "#{following_user.name} さんをフォロー解除しますか？" %></p>
+      <p class="text-confirm"><%= "@#{following_user.user_name} さんをフォロー解除しますか？" %></p>
       <p class="text-guide">このアカウントのツイートはホームタイムラインに表示されなくなります。ツイートが非公開になっている場合を除き、プロフィールを表示することはできます。</p>
       <%= button_to 'フォロー解除', unfollow_user_path(following_user), method: :delete, class: 'follow-madal-button', id: "unfollowButton_#{following_user.id}" %>
       <button class="cancelUnfollow">キャンセル</button>

--- a/app/views/follows/index.html.erb
+++ b/app/views/follows/index.html.erb
@@ -5,10 +5,7 @@
 <div class="main_area follow_main">
     <div class="follow_user_area">
       <div class="flexbox">
-        <%= link_to user_path(@user), class: "back-to-user-button" do %>
-          <i class="fa fa-arrow-left"></i>
-        <% end %>
-
+        <%= link_to "←", user_path(@user), class: "back-to-user-button" %>
         <div class="info_container">
             <div class="follow_name">
               <p><%= @user.name %></p>
@@ -36,9 +33,13 @@
            <div class="flexbox followings_user">
              <div class="follow-date-icon">
                <% if following_user && following_user.user_icon.attached? %>
-                 <%= image_tag following_user.user_icon, class: "rounded-image"%>
+                <%= link_to user_path(following_user) do %>
+                  <%= image_tag following_user.user_icon, class: "rounded-image"%>
+                <% end %>
                <% else %>
-                 <%= image_tag('prum.png') %>
+                  <%= link_to user_path(following_user) do %>
+                    <%= image_tag 'prum.png', class: "author-icon" %>
+                  <% end %>
                <% end %>
              </div>
    

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,8 @@
     <%# 画面推移時リロード%>
     <meta name="turbo-visit-control" content="reload">
 
-    
+    <%= favicon_link_tag('prum.png') %>
+
   </head>
 
   <body>

--- a/app/views/posts/_index.html.erb
+++ b/app/views/posts/_index.html.erb
@@ -29,7 +29,7 @@
 
     <div class="tweet-reaction">
       <%= image_tag('comment.svg', alt: 'Icon', class: 'comment-img') %>
-      <p class="comment-count"><%= post.comments.count %></p>
+      <p class="comment-count"><%= post.comments.where(parent_id: nil).count %><%#孫コメントを表示させない %>
       
       <!-- いいね -->
       <%= render partial: 'likes/likes_btn', locals: { post: post } %>

--- a/app/views/posts/_main.html.erb
+++ b/app/views/posts/_main.html.erb
@@ -56,12 +56,11 @@
 
     <div class="tweet-reaction">
       <%= image_tag('comment.svg', alt: 'Icon', class: 'comment-img') %>
-      <p class="comment-count"><%= post.comments.count %></p>
+      <p class="comment-count"><%= post.comments.where(parent_id: nil).count %>
       
       <!--- いいね   --->
       <%= render partial: 'likes/likes_btn', locals: { post: post } %>
 
-      <%#エラー起きるため一旦保留 <%= render partial: 'likes/posts_btn' %>  
       <%= image_tag('delete.svg', alt: 'Icon', class: 'delete-img') %>
     </div>
   </div>

--- a/app/views/posts/_sidebar.html.erb
+++ b/app/views/posts/_sidebar.html.erb
@@ -26,3 +26,23 @@
 
 </div>
 
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    if (navigator.permissions) {
+      navigator.permissions.query({ name: 'geolocation' }).then(function(permissionStatus) {
+        if (permissionStatus.state === 'granted') {
+          // 位置情報の許可が得られている場合、ボタンを活性化する
+          document.querySelector(".tweet-button").disabled = false;
+        } else {
+          // 位置情報の許可が得られていない場合、ボタンを非活性化する
+          document.querySelector(".tweet-button").disabled = true;
+        }
+      });
+    } else {
+      console.error("navigator.permissions API is not supported by this browser.");
+    }
+  });
+
+</script>
+
+

--- a/app/views/posts/load_max.html.erb
+++ b/app/views/posts/load_max.html.erb
@@ -10,6 +10,26 @@
 <div class="right_area">
 </div>
 
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    if (navigator.permissions) {
+      navigator.permissions.query({ name: 'geolocation' }).then(function(permissionStatus) {
+        if (permissionStatus.state !== 'granted') {
+          // 位置情報の許可が得られなかった場合
+          disableButton();
+        }
+      });
+    } else {
+      console.error("navigator.permissions API is not supported by this browser.");
+    }
+  });
+
+  function disableButton() {
+    // ボタンを非活性化する処理
+    document.querySelector("#your_button_id").disabled = true;
+  }
+</script>
+
 
 <%# モーダル表示 %>
 <%= render 'posts/madal' %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -38,7 +38,7 @@
         </div>
         <div class="tweet-reaction">
           <%= image_tag('comment.svg', alt: 'Icon', class: 'comment-img') %>
-          <p class="comment-count"><%= @post.comments.count %></p>
+          <p class="comment-count"><%= @post.comments.where(parent_id: nil).count %><%#孫コメントを表示させない %>
           <%= render partial: 'likes/likes_btn', locals: { post: @post } %>
           <%= image_tag('delete.svg', alt: 'Icon', class: 'delete-img') %>
         </div>
@@ -164,6 +164,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
 <%# モーダル表示%>
 <%= render 'posts/madal' %>
+
 
 
 <%# fixed-areaの高さを取得しマージン設定%>

--- a/app/views/posts/top.html.erb
+++ b/app/views/posts/top.html.erb
@@ -11,10 +11,25 @@
 </div>
 
 
-<%# モーダル表示 %>
-<%= render 'posts/madal' %>
+
 
 <script>
+  document.addEventListener("DOMContentLoaded", function() {
+    if (navigator.permissions) {
+      navigator.permissions.query({ name: 'geolocation' }).then(function(permissionStatus) {
+        if (permissionStatus.state === 'granted') {
+          // 位置情報の許可が得られている場合、ボタンを活性化する
+          document.querySelector(".top-tweet").disabled = false;
+        } else {
+          // 位置情報の許可が得られていない場合、ボタンを非活性化する
+          document.querySelector(".top-tweet").disabled = true;
+        }
+      });
+    } else {
+      console.error("navigator.permissions API is not supported by this browser.");
+    }
+  });
+
   function updateLocation(event, formSelector) {
     event.preventDefault(); // フォームのデフォルトの動作を防ぐ
 
@@ -33,6 +48,8 @@
         },
         function(error) {
           console.error("Error getting geolocation:", error.message);
+          // 位置情報の取得に失敗した場合、ボタンを非活性にする
+          document.querySelector(".top-tweet").disabled = true;
         }
       );
     } else {

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -46,10 +46,14 @@ ja:
           attributes:
             name:
               blank: "を入力してください"
+              too_short: "は%{count}文字以上で入力してください"
+              too_long: "は%{count}文字以内で入力してください"
             user_name:
               blank: "を入力してください"
               taken: "はすでに使用されています"
               invalid: "は英数字とアンダースコアのみ使用できます"
+              too_short: "は%{count}文字以上で入力してください"
+              too_long: "は%{count}文字以内で入力してください"
             email:
               blank: "を入力してください"
               invalid: "が無効です"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     resources :likes, only: [:create, :destroy] # コメントに関連付けられたいいね用のルートを追加
   end
   
-  resources :posts do
+  resources :posts,only: [:index, :show, :edit, :create, :destroy, :update] do
     resources :likes, only: [:create, :destroy] # 投稿に関連付けられたいいね用のルートを追加
   end
 


### PR DESCRIPTION
# 概要
バグ修正


# 実装内容: ファビコン,ホバー時ポインター, フォロー削除モーダル（＠のついた名前）

現状:ファビコンなし,ホバー時にポインターにならない,フォロー削除モーダルの表示が（name）

期待値:ファビコンあり,ポインターになる,フォロー削除モーダルの表示が（user_name）

デザイン（FigmaURL）
https://www.figma.com/file/l8Zzw1wPJBitm0bQMNXTdB/%E3%82%A4%E3%83%9E%E3%82%B3%E3%82%B3SNS?type=design&node-id=0-1&mode=design

# エビデンス
![135F66A7-12C9-4E7F-A6E9-56BFFEE15E8A](https://github.com/hallelujah8068/7th_imakoko_SNS/assets/147670796/39ded331-dfcf-4b6d-bb71-360b2b223181)
※ツイートボタンのポンンターはスクショだと映らないため省略

# 備考・注意点
特になし