### PR TITLE
Fix#149

### DIFF
--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -77,6 +77,10 @@ input[type="submit"].top-tweet:disabled {
   /* グレーなどの適切な色に変更 */
 }
 
+input[type="submit"].top-tweet:hover {
+  cursor: pointer;
+}
+
 .relord-tweets {
   margin-top: 206px;
   color: #707070;

--- a/app/assets/stylesheets/top.css
+++ b/app/assets/stylesheets/top.css
@@ -96,6 +96,10 @@ li {
 
 }
 
+.tweet-button:hover {
+  cursor: pointer;
+}
+
 .tweet-button:disabled {
   background-color: #707070;
   border: 2px solid #707070;

--- a/app/views/followers/index.html.erb
+++ b/app/views/followers/index.html.erb
@@ -58,7 +58,7 @@
 <% @followers.each do |follower| %>
   <div id="unfollowModal_<%= follower.id %>" class="modal">
     <div class="modal-content">
-      <p class="text-confirm"><%= "#{follower.name} さんをフォロー解除しますか？" %></p>
+      <p class="text-confirm"><%= "＠#{follower.user_name} さんをフォロー解除しますか？" %></p>
       <p class="text-guide">このアカウントのツイートはホームタイムラインに表示されなくなります。ツイートが非公開になっている場合を除き、プロフィールを表示することはできます。</p>
       <%= button_to 'フォロー解除', unfollow_user_path(follower), method: :delete, class: 'follow-madal-button', id: "unfollowButton_#{follower.id}" %>
       <button class="cancelUnfollow">キャンセル</button>

--- a/app/views/follows/index.html.erb
+++ b/app/views/follows/index.html.erb
@@ -75,7 +75,7 @@
 <% @followed_users.each do |following_user| %>
   <div id="unfollowModal_<%= following_user.id %>" class="modal">
     <div class="modal-content">
-      <p class="text-confirm"><%= "#{following_user.name} さんをフォロー解除しますか？" %></p>
+      <p class="text-confirm"><%= "@#{following_user.user_name} さんをフォロー解除しますか？" %></p>
       <p class="text-guide">このアカウントのツイートはホームタイムラインに表示されなくなります。ツイートが非公開になっている場合を除き、プロフィールを表示することはできます。</p>
       <%= button_to 'フォロー解除', unfollow_user_path(following_user), method: :delete, class: 'follow-madal-button', id: "unfollowButton_#{following_user.id}" %>
       <button class="cancelUnfollow">キャンセル</button>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,8 @@
     <%# 画面推移時リロード%>
     <meta name="turbo-visit-control" content="reload">
 
-    
+    <%= favicon_link_tag('prum.png') %>
+
   </head>
 
   <body>


### PR DESCRIPTION
# 概要
バグ修正


# 実装内容: ファビコン,ホバー時ポインター, フォロー削除モーダル（＠のついた名前）

現状:ファビコンなし,ホバー時にポインターにならない,フォロー削除モーダルの表示が（name）

期待値:ファビコンあり,ポインターになる,フォロー削除モーダルの表示が（user_name）

デザイン（FigmaURL）
https://www.figma.com/file/l8Zzw1wPJBitm0bQMNXTdB/%E3%82%A4%E3%83%9E%E3%82%B3%E3%82%B3SNS?type=design&node-id=0-1&mode=design

# エビデンス
![135F66A7-12C9-4E7F-A6E9-56BFFEE15E8A](https://github.com/hallelujah8068/7th_imakoko_SNS/assets/147670796/39ded331-dfcf-4b6d-bb71-360b2b223181)
※ツイートボタンのポンンターはスクショだと映らないため省略

# 備考・注意点
特になし