### PR TITLE
Fix#155

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,3 +91,6 @@ gem 'paranoia'
 
 #ajax
 gem 'jquery-rails'
+
+#seedデータ作成
+gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
+    faker (3.2.3)
+      i18n (>= 1.8.11, < 2)
     ffi (1.16.3)
     font-awesome-sass (5.15.1)
       sassc (>= 1.11)
@@ -116,7 +118,6 @@ GEM
     globalid (1.1.0)
       activesupport (>= 5.0)
     gmaps4rails (2.1.2)
-    htmx-rails (0.2.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
@@ -298,10 +299,10 @@ DEPENDENCIES
   devise-i18n
   dotenv-rails
   factory_bot_rails
+  faker
   font-awesome-sass (~> 5.0)
   geocoder
   gmaps4rails
-  htmx-rails
   importmap-rails
   jbuilder
   jquery-rails

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,27 +3,23 @@ before_action :authenticate_user!
 before_action :set_cache_headers
 
     def top
-      @posts = Post.all.order(created_at: :desc).limit(30)
-      # ツイート作成
-      @post_new =Post.new
+      @posts = current_user.following_posts.order(created_at: :desc).limit(30)
+      @post_new = Post.new
       @user = @post_new.user
     end
 
-    #TOP画面で100件のツイートを取得を押すと以下アクションで変数を再設定
     def load_more
-      @posts = Post.all.order(created_at: :desc).limit(100)
-      # ツイート作成
-      @post_new =Post.new
+      @posts = current_user.following_posts.order(created_at: :desc).limit(100)
+      @post_new = Post.new
       @user = @post_new.user
     end
 
-    # 全てのツイートを取得
     def load_max 
-      @posts = Post.all.order(created_at: :desc)
-      @post_new =Post.new
+      @posts = current_user.following_posts.order(created_at: :desc)
+      @post_new = Post.new
       @user = @post_new.user
     end
-    
+
 
     def show
       @post = Post.find(params[:id])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,4 +55,9 @@ class User < ApplicationRecord
   def following?(user)
     followings.include?(user)
   end
+
+  def following_posts
+    following_ids = self.following.pluck(:id)
+    Post.where(user_id: following_ids)
+  end
 end

--- a/app/views/posts/_main.html.erb
+++ b/app/views/posts/_main.html.erb
@@ -61,7 +61,9 @@
       <!--- いいね   --->
       <%= render partial: 'likes/likes_btn', locals: { post: post } %>
 
-      <%= image_tag('delete.svg', alt: 'Icon', class: 'delete-img') %>
+      <% if current_user && post.user == current_user %>
+        <%= image_tag('delete.svg', alt: 'Icon', class: 'delete-img') %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,52 +1,32 @@
 # ユーザーの作成
 users = []
 
-5.times do |n|
+30.times do |n|
   user = User.create!(
-    email: "user#{n + 1}@example.com",
+    email: Faker::Internet.email,
     password: 'password',
-    name: "User#{n + 1}",
-    user_name: "user#{n + 1}",
-    thumbnail_path: '/path/to/thumbnail1.jpg',
-    description: "Description for User #{n + 1}"
+    name: Faker::Name.name,
+    user_name: Faker::Internet.unique.username(specifier: 5..8), # ユニークなユーザー名を生成
+    description: Faker::Lorem.sentence
   )
   users << user
 end
 
-# ユーザー2がフォローしているユーザーを3人作成
-user2 = users[1] # ユーザー2を取得
-
-# ユーザー2以外のユーザーからランダムに3人を選択してフォロー
-following_users = users.reject { |user| user == user2 }.sample(3)
-
-following_users.each do |following_user|
-  Follow.create!(
-    following: following_user,
-    follower: user2
-  )
-end
-
-# ポストの作成
-posts = []
+# ポストの作成とコメントの作成
 users.each do |user|
-  3.times do
-    posts << Post.create!(
-      user: user,
-      body: "デフォルト投稿",
-      latitude: 35.6895,
-      longitude: 139.6917
+  5.times do
+    post = Post.create!(
+      user_id: user.id,
+      body: Faker::Lorem.paragraph(sentence_count: 3), # ランダムな本文を生成
+      latitude: Faker::Address.latitude,
+      longitude: Faker::Address.longitude
     )
-  end
-end
 
-# コメントの作成
-users.each do |user|
-  posts.each do |post|
-    1.times do
+    5.times do
       Comment.create!(
-        user: user,
-        post: post,
-        body: "デフォルトコメント"
+        user_id: users.sample.id, # ランダムなユーザーからコメントを作成
+        post_id: post.id,
+        body: Faker::Lorem.sentence
       )
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,10 +6,21 @@ users = []
     email: Faker::Internet.email,
     password: 'password',
     name: Faker::Name.name,
-    user_name: Faker::Internet.unique.username(specifier: 5..8), # ユニークなユーザー名を生成
+    user_name: Faker::Internet.unique.username(specifier: 5..8),
     description: Faker::Lorem.sentence
   )
   users << user
+end
+
+# フォロー関係の作成
+users.each do |user|
+  # ユーザー自身を除いた他のユーザーからランダムに3人を選択
+  following_users = users.reject { |u| u == user }.sample(3)
+
+  following_users.each do |following_user|
+    # フォロー関係を保存
+    user.following << following_user
+  end
 end
 
 # ポストの作成とコメントの作成
@@ -17,14 +28,14 @@ users.each do |user|
   5.times do
     post = Post.create!(
       user_id: user.id,
-      body: Faker::Lorem.paragraph(sentence_count: 3), # ランダムな本文を生成
+      body: Faker::Lorem.paragraph(sentence_count: 3),
       latitude: Faker::Address.latitude,
       longitude: Faker::Address.longitude
     )
 
     5.times do
       Comment.create!(
-        user_id: users.sample.id, # ランダムなユーザーからコメントを作成
+        user_id: users.sample.id,
         post_id: post.id,
         body: Faker::Lorem.sentence
       )


### PR DESCRIPTION
# 概要
バグ修正

# 実装内容: シードデータ作成、削除ボタン、ツイート表示

現状:シードデータが少ない、他ユーザーの投稿に削除ボタンがある、トップページに全てのユーザーの投稿が表示

期待値:シードデータを作成（ユーザー30人、各５ツイート、５コメント、ランダムで3人をフォロー）
　　　 他ユーザーの投稿には削除ボタンは表示させない、トップページにはフォローユーザーの投稿のみを表示

デザイン（FigmaURL）
https://www.figma.com/file/l8Zzw1wPJBitm0bQMNXTdB/%E3%82%A4%E3%83%9E%E3%82%B3%E3%82%B3SNS?type=design&node-id=0-1&mode=design

# エビデンス
<img width="1440" alt="スクリーンショット 2024-03-24 14 23 23" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/147670796/2e835972-bc0c-4732-961f-f7471bffdb14">
<img width="1440" alt="スクリーンショット 2024-03-24 14 21 26" src="https://github.com/hallelujah8068/7th_imakoko_SNS/assets/147670796/288b14d9-1cfb-48d1-bf31-c351f3cc52f9">


# 備考・注意点
特になし